### PR TITLE
Fix Animcube

### DIFF
--- a/docs/techniques/F2L.md
+++ b/docs/techniques/F2L.md
@@ -1,10 +1,8 @@
 # F2L
 
-<script src="/assets/animcube/AnimCube3.js"></script>
-
 !!! example "3^3^ with the F2L step completed"
 <div style="width:200px; height:219px">
-    <script>AnimCube3("config=/docs/assets/animcube/AnimCube3.txt")</script>
+    <script>AnimCube3("config=assets/animcube/AnimCube3.txt")</script>
 </div>
 
 First 2 Layers (F2L) is a solving technique for cubes and some other puzzles that involves pairing pieces and inserting those pairs into slots to build up the first 2 layers (of a 3-layered puzzle). The first known [description of this technique](https://www.cubinghistory.com/3x3/Methods/CFOP#first-two-layers) was by [John Conway](https://en.wikipedia.org/wiki/John_Horton_Conway) in 1979, but is most commonly credited to Jessica Fridrich due to the massive popularity her website describing the CFOP method had in the early 1990s.

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+<script src="/assets/animcube/AnimCube2.js"></script>
+<script src="/assets/animcube/AnimCube3.js"></script>
+<script src="/assets/animcube/AnimCube4.js"></script>
+{% endblock %}


### PR DESCRIPTION
Fixed Animcube by moving the Animcube scripts to the `<head>` of the HTML page. That way it loads before the rest of the page