### PR TITLE
Fix <p> tags and move `#` description to canonical moves page

### DIFF
--- a/docs/puzzles/physical/2x2x2x2/scramble-generator.md
+++ b/docs/puzzles/physical/2x2x2x2/scramble-generator.md
@@ -1,8 +1,8 @@
 # Physical 2×2×2×2 Scramble Generator
 
 <p>Reminders:</p>
-    <p># is U2, L->R</p>
-    <p>Starting orientation is Green-Front, Orange-Left, White-Up, Pink-Out</p>
+    # is U2, L->R
+    Starting orientation is Green-Front, Orange-Left, White-Up, Pink-Out
 
 <p>Scrambles: <span id="demo2">5</span></p>
 <input type="range" min="1" max="20" value="5" class="slider" id="myRange">


### PR DESCRIPTION
In the current build it appears that the <p> and the </p> appear when viewing the page, which they shouldn't, so I removed them, and I hope it doesn't break anything while getting rid of these erroneous marks