### PR TITLE
Leaderboard tweaks

### DIFF
--- a/docs/javascripts/leaderboards.js
+++ b/docs/javascripts/leaderboards.js
@@ -1,10 +1,29 @@
-console.log("it is working");
-function hide() {
-    var alist = document.getElementsByClassName("timetext");
-    console.log(alist);
-}
+
+var shortList = document.getElementsByClassName("shorttime");
+var longList = document.getElementsByClassName("longtime");
 
 function LongTime() {
     // switches to the long time format
-    console.log("switching to long time format on the leaderboards");
+    for (var i = 0; i < shortList.length; i++) {
+        shortList[i].style.display = "none";
+        longList[i].style.display = "block";
+    } 
+    document.getElementById("long-time-format").classList.add("md-button--primary"); 
+    document.getElementById("wca-time-format").classList.remove("md-button--primary"); 
 }
+
+function ShortTime() {
+    // switches to the short time format
+    for (var i = 0; i < longList.length; i++) {
+        longList[i].style.display = "none";
+        shortList[i].style.display = "block";
+    }  
+    document.getElementById("long-time-format").classList.remove("md-button--primary"); 
+    document.getElementById("wca-time-format").classList.add("md-button--primary"); 
+}
+
+document.addEventListener("DOMContentLoaded", (event) => {
+    for (var i = 0; i < shortList.length; i++) {
+        shortList[i].style.display = "none";
+    }
+});

--- a/docs/javascripts/leaderboards.js
+++ b/docs/javascripts/leaderboards.js
@@ -4,6 +4,7 @@ function hide() {
     console.log(alist);
 }
 
-function msg(){  
-    alert("Hello Javatpoint");  
-   }  
+function LongTime() {
+    // switches to the long time format
+    console.log("switching to long time format on the leaderboards");
+}

--- a/docs/javascripts/leaderboards.js
+++ b/docs/javascripts/leaderboards.js
@@ -10,6 +10,7 @@ function LongTime() {
     } 
     document.getElementById("long-time-format").classList.add("md-button--primary"); 
     document.getElementById("wca-time-format").classList.remove("md-button--primary"); 
+    sessionStorage.setItem("timeFormat", "long");
 }
 
 function ShortTime() {
@@ -20,10 +21,23 @@ function ShortTime() {
     }  
     document.getElementById("long-time-format").classList.remove("md-button--primary"); 
     document.getElementById("wca-time-format").classList.add("md-button--primary"); 
+    sessionStorage.setItem("timeFormat", "short");
+    
 }
 
-document.addEventListener("DOMContentLoaded", (event) => {
-    for (var i = 0; i < shortList.length; i++) {
-        shortList[i].style.display = "none";
+
+
+document.addEventListener("DOMContentLoaded", load);
+document.addEventListener("hashchange", load);
+
+function load() {
+    console.log("loaded thing");
+    var format = sessionStorage.getItem("timeFormat");
+    if (format == "short") {
+        ShortTime();
+    } else {
+        LongTime();
     }
-});
+}
+
+load();

--- a/docs/javascripts/leaderboards.js
+++ b/docs/javascripts/leaderboards.js
@@ -1,0 +1,9 @@
+console.log("it is working");
+function hide() {
+    var alist = document.getElementsByClassName("timetext");
+    console.log(alist);
+}
+
+function msg(){  
+    alert("Hello Javatpoint");  
+   }  

--- a/docs/leaderboards/other-leaderboards.md
+++ b/docs/leaderboards/other-leaderboards.md
@@ -1,0 +1,27 @@
+---
+title: Other Leaderboards
+---
+
+# Other Leaderboards
+
+
+[Magic Cube 4D Hall of Fame](https://superliminal.com/cube/halloffame.htm)
+- The original Hall of Fame. New submissions are no longer accepted due to reaching 500 solvers.
+
+[Magic Cube 4D Extended Records](http://wiki.superliminal.com/wiki/MC4D_Records)
+- Records for many other puzzles found in [MC4D](/software/magiccube4d.md).
+
+[Magic Cube 5D Hall of Insanity](http://www.gravitation3d.com/magiccube5d/hallofinsanity.html)
+- List of everyone who has solved 2^5^-7^5^, and also FMC solutions.
+
+[Magic Cube 7D Solvers](https://superliminal.com/andrey/mc7d/)
+- List of 6D and 7D solvers in MC7D.
+
+[Magic 120 Cell Solvers](http://www.gravitation3d.com/magic120cell/index.html)
+- List of 120 cell solvers in M120C or MPU.
+
+[MagicTile Klein Bottle challenge](http://roice3.org/magictile/mathologer/)
+- List of the first 100 people to solve the Klein Bottle Rubik's Cube from a [competition video](https://www.youtube.com/watch?v=DvZnh7-nslo) made by [Mathologer](https://www.youtube.com/@Mathologer).
+
+[Speedsolving Wiki List of Unofficial World Records](https://www.speedsolving.com/wiki/index.php?title=List_of_Unofficial_World_Records#High_Dimensional_Puzzles)
+- List of a few speedsolving and FMC records.

--- a/leaderboards/generate_leaderboards.py
+++ b/leaderboards/generate_leaderboards.py
@@ -114,12 +114,6 @@ class Solve:
             if self.rank is None:
                 return ''
             emoji = ''
-            # if 1 <= self.rank <= 3:
-            #     emoji = [
-            #         ':first_place: ',
-            #         ':second_place: ',
-            #         ':third_place: ',
-            #     ][self.rank-1]
             if self.rank == 1:
                 emoji = ':trophy-gold-hypercube: '
             elif self.rank == 2:
@@ -210,29 +204,20 @@ with open('leaderboards/tabs.yml') as tabs_file:
 
 
 def parse_time(s):
-    # if m := re.match(r'(\d+)mv', s):
-    #     return int(m[1])
-    # m = re.match(
-    #     r'(?:(\d+)d\s*)?(?:(\d+)h\s*)?(?:(\d+)m\s*)?(?:(\d+(?:\.\d+)?)s)', s)
-    # return timedelta(
-    #     days=int(m[1] or '0'),
-    #     hours=int(m[2] or '0'),
-    #     minutes=int(m[3] or '0'),
-    #     seconds=float(m[4]),
-    # )
-    timelist = s.split(":")
-    while len(timelist) != 4:
-        timelist.insert(0, '0')
+    if m := re.match(r'(\d+)mv', s):
+        return int(m[1])
+    m = re.match(
+        r'(?:(\d+)d\s*)?(?:(\d+)h\s*)?(?:(\d+)m\s*)?(?:(\d+(?:\.\d+)?)s)', s)
     return timedelta(
-        days=int(timelist[0]),
-        hours=int(timelist[1]),
-        minutes=int(timelist[2]),
-        seconds=float(timelist[3]),
+        days=int(m[1] or '0'),
+        hours=int(m[2] or '0'),
+        minutes=int(m[3] or '0'),
+        seconds=float(m[4]),
     )
 
 
 # Load solves from CSV
-with open('leaderboards/test.csv') as file:
+with open('leaderboards/solves.csv') as file:
     reader = csv.reader(file)
     headers = [str.strip(s) for s in next(reader)]
     all_solves = [Solve(**dict(zip(headers, map(str.strip, line))))

--- a/leaderboards/generate_leaderboards.py
+++ b/leaderboards/generate_leaderboards.py
@@ -43,8 +43,10 @@ def format_time(duration) -> str:  # duration: timedelta | int
 
     # converts duration into a string. Then it chops off leading 0's because a TimeDelta object has those for some reason 
     timestr = str(duration)
-    if (timestr.find(".") != -1):
+    if (timestr.find(".") != -1):   # if the string has a decimal point
         timestr = timestr[0:-4] # chop off the extra four 0's at the end if the time includes a non-integer number of seconds
+    if (timestr.find(".") == -1):   # if the string does not have a decimal point, add ".00" to the end
+        timestr += ".00"
 
     while timestr[0:1] == "0":  # while there are leading 0's to chop off
         timestr = timestr[1:len(timestr)]   # chop off leading 0

--- a/leaderboards/generate_leaderboards.py
+++ b/leaderboards/generate_leaderboards.py
@@ -66,7 +66,16 @@ def format_time(duration) -> str:  # duration: timedelta | int
     # hours_str = f"{minutes:02}{unit('h')}"
 
     # return f"{days:,}{unit('d')} {hours_str} {minutes_str} {seconds_str} {millis_str}".replace(',', '\u2009')
-    return duration
+
+    timestr = str(duration)
+    timestr = timestr[0:(len(timestr)-4)] # chop off the extra four 0's at the end
+
+    while timestr[0:1] == "0":  # while there are leading 0's to chop off
+        if timestr[0:2] == "0:":
+            timestr = timestr[2:len(timestr)]   # chop off "0:" (if the hours are empty) 
+        elif timestr[0:1] == "0":
+            timestr = timestr[1:len(timestr)]   # chop off leading 0 on minutes
+    return timestr
 
 
 class Solve:

--- a/leaderboards/generate_leaderboards.py
+++ b/leaderboards/generate_leaderboards.py
@@ -75,7 +75,7 @@ def format_time(duration) -> str:  # duration: timedelta | int
             timestr = timestr[2:len(timestr)]   # chop off "0:" (if the hours are empty) 
         elif timestr[0:1] == "0":
             timestr = timestr[1:len(timestr)]   # chop off leading 0 on minutes
-    return timestr
+    return "<strong>" + timestr + "</strong>"
 
 
 class Solve:

--- a/leaderboards/generate_leaderboards.py
+++ b/leaderboards/generate_leaderboards.py
@@ -41,20 +41,55 @@ def get_template(filename):
 def format_time(duration) -> str:  # duration: timedelta | int
     # duration can be timedelta (time) or int (movecount for fmc)
 
+    # gets the time in a short format (ex: 8:48:23.15)
     # converts duration into a string. Then it chops off leading 0's because a TimeDelta object has those for some reason 
-    timestr = str(duration)
-    if (timestr.find(".") != -1):   # if the string has a decimal point
-        timestr = timestr[0:-4] # chop off the extra four 0's at the end if the time includes a non-integer number of seconds
-    if (timestr.find(".") == -1):   # if the string does not have a decimal point, add ".00" to the end
-        timestr += ".00"
+    shortTime = str(duration)
+    if (shortTime.find(".") != -1):   # if the string has a decimal point
+        shortTime = shortTime[0:-4] # chop off the extra four 0's at the end if the time includes a non-integer number of seconds
+    if (shortTime.find(".") == -1):   # if the string does not have a decimal point, add ".00" to the end
+        shortTime += ".00"
 
-    while timestr[0:1] == "0":  # while there are leading 0's to chop off
-        timestr = timestr[1:len(timestr)]   # chop off leading 0
-        if timestr[0:1] == ":":             # if next character is a colon
-            timestr = timestr[1:len(timestr)]   # chop off colon
+    while shortTime[0:1] == "0":  # while there are leading 0's to chop off
+        shortTime = shortTime[1:len(shortTime)]   # chop off leading 0
+        if shortTime[0:1] == ":":             # if next character is a colon
+            shortTime = shortTime[1:len(shortTime)]   # chop off colon
 
-    return "<class='timetext'>" + timestr + "</>"
-    # return timestr
+    returnString = "<p class='shorttime'>" + shortTime + "</p><p class='longtime'>"
+
+    # code for geting time string in long format (ex: 8h 4m 32s 592ms)
+    def unit(s):
+        return f'<small>{s}</small>'
+
+    # this is if duration is actually FMC movecount, I think
+    if isinstance(duration, int):
+        return f"{duration:,}".replace(',', '\u2009')
+
+    millis = int(round(duration.total_seconds() * 1000))
+    seconds, millis = divmod(millis, 1000)
+    millis_str = f"{millis:03}{unit('ms')}"
+
+    minutes, seconds = divmod(seconds, 60)
+    if minutes == 0:
+        longTime = f"{seconds}{unit('s')} {millis_str}"
+        return returnString + longTime + "</p>"
+    seconds_str = f"{seconds:02}{unit('s')}"
+
+    hours, minutes = divmod(int(minutes), 60)
+    if hours == 0:
+        longTime = f"{minutes}{unit('m')} {seconds_str} {millis_str}"
+        return returnString + longTime + "</p>"
+    minutes_str = f"{minutes:02}{unit('m')}"
+
+    days, hours = divmod(int(hours), 24)
+    if days == 0:
+        longTime = f"{hours}{unit('h')} {minutes_str} {seconds_str} {millis_str}"
+        return returnString + longTime + "</p>"
+    hours_str = f"{minutes:02}{unit('h')}"
+
+    longTime = f"{days:,}{unit('d')} {hours_str} {minutes_str} {seconds_str} {millis_str}".replace(',', '\u2009')
+    # return "<p class='shorttime'>" + shortTime + "</p><p class='longtime'>" + longTime + "</p>"
+    return returnString + longTime + "</p>"
+
 
 
 class Solve:

--- a/leaderboards/generate_leaderboards.py
+++ b/leaderboards/generate_leaderboards.py
@@ -40,32 +40,33 @@ def get_template(filename):
 
 def format_time(duration) -> str:  # duration: timedelta | int
     # duration can be timedelta (time) or int (movecount for fmc)
-    def unit(s):
-        return f'<small>{s}</small>'
+    # def unit(s):
+    #     return f'<small>{s}</small>'
 
-    if isinstance(duration, int):
-        return f"{duration:,}".replace(',', '\u2009')
+    # if isinstance(duration, int):
+    #     return f"{duration:,}".replace(',', '\u2009')
 
-    millis = int(round(duration.total_seconds() * 1000))
-    seconds, millis = divmod(millis, 1000)
-    millis_str = f"{millis:03}{unit('ms')}"
+    # millis = int(round(duration.total_seconds() * 1000))
+    # seconds, millis = divmod(millis, 1000)
+    # millis_str = f"{millis:03}{unit('ms')}"
 
-    minutes, seconds = divmod(seconds, 60)
-    if minutes == 0:
-        return f"{seconds}{unit('s')} {millis_str}"
-    seconds_str = f"{seconds:02}{unit('s')}"
+    # minutes, seconds = divmod(seconds, 60)
+    # if minutes == 0:
+    #     return f"{seconds}{unit('s')} {millis_str}"
+    # seconds_str = f"{seconds:02}{unit('s')}"
 
-    hours, minutes = divmod(int(minutes), 60)
-    if hours == 0:
-        return f"{minutes}{unit('m')} {seconds_str} {millis_str}"
-    minutes_str = f"{minutes:02}{unit('m')}"
+    # hours, minutes = divmod(int(minutes), 60)
+    # if hours == 0:
+    #     return f"{minutes}{unit('m')} {seconds_str} {millis_str}"
+    # minutes_str = f"{minutes:02}{unit('m')}"
 
-    days, hours = divmod(int(hours), 24)
-    if days == 0:
-        return f"{hours}{unit('h')} {minutes_str} {seconds_str} {millis_str}"
-    hours_str = f"{minutes:02}{unit('h')}"
+    # days, hours = divmod(int(hours), 24)
+    # if days == 0:
+    #     return f"{hours}{unit('h')} {minutes_str} {seconds_str} {millis_str}"
+    # hours_str = f"{minutes:02}{unit('h')}"
 
-    return f"{days:,}{unit('d')} {hours_str} {minutes_str} {seconds_str} {millis_str}".replace(',', '\u2009')
+    # return f"{days:,}{unit('d')} {hours_str} {minutes_str} {seconds_str} {millis_str}".replace(',', '\u2009')
+    return duration
 
 
 class Solve:
@@ -200,20 +201,29 @@ with open('leaderboards/tabs.yml') as tabs_file:
 
 
 def parse_time(s):
-    if m := re.match(r'(\d+)mv', s):
-        return int(m[1])
-    m = re.match(
-        r'(?:(\d+)d\s*)?(?:(\d+)h\s*)?(?:(\d+)m\s*)?(?:(\d+(?:\.\d+)?)s)', s)
+    # if m := re.match(r'(\d+)mv', s):
+    #     return int(m[1])
+    # m = re.match(
+    #     r'(?:(\d+)d\s*)?(?:(\d+)h\s*)?(?:(\d+)m\s*)?(?:(\d+(?:\.\d+)?)s)', s)
+    # return timedelta(
+    #     days=int(m[1] or '0'),
+    #     hours=int(m[2] or '0'),
+    #     minutes=int(m[3] or '0'),
+    #     seconds=float(m[4]),
+    # )
+    timelist = s.split(":")
+    while len(timelist) != 4:
+        timelist.insert(0, '0')
     return timedelta(
-        days=int(m[1] or '0'),
-        hours=int(m[2] or '0'),
-        minutes=int(m[3] or '0'),
-        seconds=float(m[4]),
+        days=int(timelist[0]),
+        hours=int(timelist[1]),
+        minutes=int(timelist[2]),
+        seconds=float(timelist[3]),
     )
 
 
 # Load solves from CSV
-with open('leaderboards/solves.csv') as file:
+with open('leaderboards/test.csv') as file:
     reader = csv.reader(file)
     headers = [str.strip(s) for s in next(reader)]
     all_solves = [Solve(**dict(zip(headers, map(str.strip, line))))

--- a/leaderboards/generate_leaderboards.py
+++ b/leaderboards/generate_leaderboards.py
@@ -40,36 +40,11 @@ def get_template(filename):
 
 def format_time(duration) -> str:  # duration: timedelta | int
     # duration can be timedelta (time) or int (movecount for fmc)
-    # def unit(s):
-    #     return f'<small>{s}</small>'
 
-    # if isinstance(duration, int):
-    #     return f"{duration:,}".replace(',', '\u2009')
-
-    # millis = int(round(duration.total_seconds() * 1000))
-    # seconds, millis = divmod(millis, 1000)
-    # millis_str = f"{millis:03}{unit('ms')}"
-
-    # minutes, seconds = divmod(seconds, 60)
-    # if minutes == 0:
-    #     return f"{seconds}{unit('s')} {millis_str}"
-    # seconds_str = f"{seconds:02}{unit('s')}"
-
-    # hours, minutes = divmod(int(minutes), 60)
-    # if hours == 0:
-    #     return f"{minutes}{unit('m')} {seconds_str} {millis_str}"
-    # minutes_str = f"{minutes:02}{unit('m')}"
-
-    # days, hours = divmod(int(hours), 24)
-    # if days == 0:
-    #     return f"{hours}{unit('h')} {minutes_str} {seconds_str} {millis_str}"
-    # hours_str = f"{minutes:02}{unit('h')}"
-
-    # return f"{days:,}{unit('d')} {hours_str} {minutes_str} {seconds_str} {millis_str}".replace(',', '\u2009')
-
+    # converts duration into a string. Then it chops off leading 0's because a TimeDelta object has those for some reason 
     timestr = str(duration)
     if (timestr.find(".") != -1):
-        timestr = timestr[0:-4)] # chop off the extra four 0's at the end if the time includes a non-integer number of seconds
+        timestr = timestr[0:-4] # chop off the extra four 0's at the end if the time includes a non-integer number of seconds
 
     while timestr[0:1] == "0":  # while there are leading 0's to chop off
         timestr = timestr[1:len(timestr)]   # chop off leading 0

--- a/leaderboards/generate_leaderboards.py
+++ b/leaderboards/generate_leaderboards.py
@@ -53,7 +53,8 @@ def format_time(duration) -> str:  # duration: timedelta | int
         if timestr[0:1] == ":":             # if next character is a colon
             timestr = timestr[1:len(timestr)]   # chop off colon
 
-    return "<strong>" + timestr + "</strong>"
+    return "<class='timetext'>" + timestr + "</>"
+    # return timestr
 
 
 class Solve:

--- a/leaderboards/generate_leaderboards.py
+++ b/leaderboards/generate_leaderboards.py
@@ -54,7 +54,7 @@ def format_time(duration) -> str:  # duration: timedelta | int
         if shortTime[0:1] == ":":             # if next character is a colon
             shortTime = shortTime[1:len(shortTime)]   # chop off colon
 
-    returnString = "<p class='shorttime'>" + shortTime + "</p><p class='longtime'>"
+    returnString = "<a class='shorttime'>" + shortTime + "</a><a class='longtime'>"
 
     # code for geting time string in long format (ex: 8h 4m 32s 592ms)
     def unit(s):
@@ -71,24 +71,25 @@ def format_time(duration) -> str:  # duration: timedelta | int
     minutes, seconds = divmod(seconds, 60)
     if minutes == 0:
         longTime = f"{seconds}{unit('s')} {millis_str}"
-        return returnString + longTime + "</p>"
+        return [longTime, shortTime]
     seconds_str = f"{seconds:02}{unit('s')}"
 
     hours, minutes = divmod(int(minutes), 60)
     if hours == 0:
         longTime = f"{minutes}{unit('m')} {seconds_str} {millis_str}"
-        return returnString + longTime + "</p>"
+        return [longTime, shortTime]
     minutes_str = f"{minutes:02}{unit('m')}"
 
     days, hours = divmod(int(hours), 24)
     if days == 0:
         longTime = f"{hours}{unit('h')} {minutes_str} {seconds_str} {millis_str}"
-        return returnString + longTime + "</p>"
+        return [longTime, shortTime]
     hours_str = f"{minutes:02}{unit('h')}"
 
     longTime = f"{days:,}{unit('d')} {hours_str} {minutes_str} {seconds_str} {millis_str}".replace(',', '\u2009')
     # return "<p class='shorttime'>" + shortTime + "</p><p class='longtime'>" + longTime + "</p>"
-    return returnString + longTime + "</p>"
+    # return returnString + longTime + "</a>"
+    return [longTime, shortTime]
 
 
 
@@ -117,7 +118,7 @@ class Solve:
         formatted_time = format_time(self.time)
         self._cell_contents = {
             'date': self.date,
-            'time': f'[{formatted_time}]({self.link})' if link else formatted_time,
+            'time': f'<a class=\'longtime\' href={self.link}>{formatted_time[0]}</a><a class=\'shorttime\' href={self.link}>{formatted_time[1]}</a>' if link else formatted_time,
             'event': self.event.name,
             'program': self.program,
             'solver': f'[{self.solver.name}]({self.solver.relative_file_path})',

--- a/leaderboards/generate_leaderboards.py
+++ b/leaderboards/generate_leaderboards.py
@@ -68,13 +68,14 @@ def format_time(duration) -> str:  # duration: timedelta | int
     # return f"{days:,}{unit('d')} {hours_str} {minutes_str} {seconds_str} {millis_str}".replace(',', '\u2009')
 
     timestr = str(duration)
-    timestr = timestr[0:(len(timestr)-4)] # chop off the extra four 0's at the end
+    if (timestr.find(".") != -1):
+        timestr = timestr[0:-4)] # chop off the extra four 0's at the end if the time includes a non-integer number of seconds
 
     while timestr[0:1] == "0":  # while there are leading 0's to chop off
-        if timestr[0:2] == "0:":
-            timestr = timestr[2:len(timestr)]   # chop off "0:" (if the hours are empty) 
-        elif timestr[0:1] == "0":
-            timestr = timestr[1:len(timestr)]   # chop off leading 0 on minutes
+        timestr = timestr[1:len(timestr)]   # chop off leading 0
+        if timestr[0:1] == ":":             # if next character is a colon
+            timestr = timestr[1:len(timestr)]   # chop off colon
+
     return "<strong>" + timestr + "</strong>"
 
 

--- a/leaderboards/generate_leaderboards.py
+++ b/leaderboards/generate_leaderboards.py
@@ -118,7 +118,7 @@ class Solve:
         formatted_time = format_time(self.time)
         self._cell_contents = {
             'date': self.date,
-            'time': f'<a class=\'longtime\' href={self.link}>{formatted_time[0]}</a><a display=\'none\' class=\'shorttime\' href={self.link}>{formatted_time[1]}</a>' if link else formatted_time,
+            'time': f'<a class=\'longtime\' href={self.link}>{formatted_time[0]}</a><a style=\'display: none\' class=\'shorttime\' href={self.link}>{formatted_time[1]}</a>' if link else formatted_time,
             'event': self.event.name,
             'program': self.program,
             'solver': f'[{self.solver.name}]({self.solver.relative_file_path})',

--- a/leaderboards/generate_leaderboards.py
+++ b/leaderboards/generate_leaderboards.py
@@ -118,7 +118,7 @@ class Solve:
         formatted_time = format_time(self.time)
         self._cell_contents = {
             'date': self.date,
-            'time': f'<a class=\'longtime\' href={self.link}>{formatted_time[0]}</a><a class=\'shorttime\' href={self.link}>{formatted_time[1]}</a>' if link else formatted_time,
+            'time': f'<a class=\'longtime\' href={self.link}>{formatted_time[0]}</a><a display=\'none\' class=\'shorttime\' href={self.link}>{formatted_time[1]}</a>' if link else formatted_time,
             'event': self.event.name,
             'program': self.program,
             'solver': f'[{self.solver.name}]({self.solver.relative_file_path})',

--- a/leaderboards/solves.csv
+++ b/leaderboards/solves.csv
@@ -620,3 +620,5 @@ date,       link,                  time, program,   solver,             puzzle, 
 2024-12-12, qA4BV6RQGZs,       2m 30.03s, HSC,      hana,               3x3x3x3, single
 2024-12-13, jtpQR1Gwq18,          18.21s, HSC,      bilal,              2x2x2x2, single
 2024-12-13, qRTIkEQ5dEU,          16.31s, HSC,      bilal,              2x2x2x2, single
+2024-12-14, -u6STfm7oeI,       4m 25.82s, HSC,      saturnb,            3x3x3x3, single
+2024-12-16, QX9X-ZKk2KM,          23.53s, HSC,      bilal,              2x2x2x2, ao5

--- a/leaderboards/templates/history.md
+++ b/leaderboards/templates/history.md
@@ -9,7 +9,7 @@ search:
 <script src="/javascripts/leaderboards.js"></script>
 
 ??? note "View Options"
-    | Time Format |  |
-    | -------     | - |
-    | Long | <input type="button" id="long-time-format" class="md-button md-button--primary" value="#m #s ###ms" onclick="LongTime()"/> |
-    | WCA  | <input type="button" id="wca-time-format" class="md-button" value="#:##.##" onclick="ShortTime()"/> |
+    | Time Format |
+    | -------     |
+    | <input type="button" id="long-time-format" class="md-button md-button--primary" value="Long (1m 00s 000ms)" onclick="LongTime()"/> |
+    | <input type="button" id="wca-time-format" class="md-button" value="WCA (1:00.00)" onclick="ShortTime()"/> |

--- a/leaderboards/templates/history.md
+++ b/leaderboards/templates/history.md
@@ -5,3 +5,11 @@ search:
 ---
 
 # World Record History
+
+<script src="/javascripts/leaderboards.js"></script>
+
+??? note "View Options"
+    | Time Format |  |
+    | -------     | - |
+    | Long | <input type="button" id="long-time-format" class="md-button md-button--primary" value="#m #s ###ms" onclick="LongTime()"/> |
+    | WCA  | <input type="button" id="wca-time-format" class="md-button" value="#:##.##" onclick="ShortTime()"/> |

--- a/leaderboards/templates/leaderboards.md
+++ b/leaderboards/templates/leaderboards.md
@@ -24,8 +24,8 @@ World record database for higher dimensional twisty puzzle speedsolving!
 [:material-plus-circle: Submit](https://forms.gle/Y7Vpi3pb8989Ay8W8){{.md-button .md-button--primary}}
 
 ??? note "View Options"
-    | Time Format |  |
-    | -------     | - |
-    | Long | <input type="button" id="long-time-format" class="md-button md-button--primary" value="#m #s ###ms" onclick="LongTime()"/> |
-    | WCA  | <input type="button" id="wca-time-format" class="md-button" value="#:##.##" onclick="ShortTime()"/> |
+    | Time Format |
+    | -------     |
+    | <input type="button" id="long-time-format" class="md-button md-button--primary" value="Long (1m 00s 000ms)" onclick="LongTime()"/> |
+    | <input type="button" id="wca-time-format" class="md-button" value="WCA (1:00.00)" onclick="ShortTime()"/> |
 

--- a/leaderboards/templates/leaderboards.md
+++ b/leaderboards/templates/leaderboards.md
@@ -25,7 +25,7 @@ World record database for higher dimensional twisty puzzle speedsolving!
 
 ??? note "View Options"
     | Time Format |  |
-    | ------- | - |
-    | Long | <input type="button" class="md-button md-button--primary" value="#m #s ###ms" onclick="LongTime()"/> |
-    | Short | <input type="button" class="md-button" value="#:##.##"/> |
+    | -------     | - |
+    | Long | <input type="button" id="long-time-format" class="md-button md-button--primary" value="#m #s ###ms" onclick="LongTime()"/> |
+    | WCA  | <input type="button" id="wca-time-format" class="md-button" value="#:##.##" onclick="ShortTime()"/> |
 

--- a/leaderboards/templates/leaderboards.md
+++ b/leaderboards/templates/leaderboards.md
@@ -12,20 +12,8 @@ search:
 
 # Leaderboards
 
-World record database for higher dimensional twisty puzzle speedsolving! Verification is done by the moderator team of the Hypercubers Discord. Please read the [submission rules](rules.md) carefully before submitting a request to add your time.
-
-??? abstract "Other places that various records are kept:"
-    - [Magic Cube 4D Hall of Fame](https://superliminal.com/cube/halloffame.htm)
-    - [Magic Cube 4D Extended Records](http://wiki.superliminal.com/wiki/MC4D_Records)
-    - [Magic Cube 5D Hall of Insanity](http://www.gravitation3d.com/magiccube5d/hallofinsanity.html)
-    - [Magic Cube 7D Solvers](https://superliminal.com/andrey/mc7d/)
-    - [Magic 120 Cell Solvers](http://www.gravitation3d.com/magic120cell/index.html)
-    - [MagicTile Klein Bottle challenge](http://roice3.org/magictile/mathologer/)
-    - [Speedsolving Wiki List of Unofficial World Records](https://www.speedsolving.com/wiki/index.php?title=List_of_Unofficial_World_Records#High_Dimensional_Puzzles)
+World record database for higher dimensional twisty puzzle speedsolving!
 
 [:material-format-list-numbered: Rules](https://hypercubing.xyz/leaderboards/rules/){{.md-button .md-button--primary}}
 [:material-plus-circle: Submit](https://forms.gle/Y7Vpi3pb8989Ay8W8){{.md-button .md-button--primary}}
 
-
-
-Happy hypercubing!

--- a/leaderboards/templates/leaderboards.md
+++ b/leaderboards/templates/leaderboards.md
@@ -10,10 +10,15 @@ search:
 <meta property="og:url" content="https://hypercubing.xyz/" />
 <meta property="og:image" content="https://assets.hypercubing.xyz/img/virt/mc4d_3x3x3x3.png" />
 
+<script src="/docs/javascripts/leaderboards.js"></script>
+
 # Leaderboards
 
 World record database for higher dimensional twisty puzzle speedsolving!
 
+<input type="button" value="click" onclick="msg()"/>  
+
 [:material-format-list-numbered: Rules](https://hypercubing.xyz/leaderboards/rules/){{.md-button .md-button--primary}}
 [:material-plus-circle: Submit](https://forms.gle/Y7Vpi3pb8989Ay8W8){{.md-button .md-button--primary}}
+[:octicons-gear-24:](){{.md-button}}
 

--- a/leaderboards/templates/leaderboards.md
+++ b/leaderboards/templates/leaderboards.md
@@ -10,15 +10,22 @@ search:
 <meta property="og:url" content="https://hypercubing.xyz/" />
 <meta property="og:image" content="https://assets.hypercubing.xyz/img/virt/mc4d_3x3x3x3.png" />
 
-<script src="/docs/javascripts/leaderboards.js"></script>
+<script src="/javascripts/leaderboards.js"></script>
 
 # Leaderboards
 
+
+
+
 World record database for higher dimensional twisty puzzle speedsolving!
 
-<input type="button" value="click" onclick="msg()"/>  
 
 [:material-format-list-numbered: Rules](https://hypercubing.xyz/leaderboards/rules/){{.md-button .md-button--primary}}
 [:material-plus-circle: Submit](https://forms.gle/Y7Vpi3pb8989Ay8W8){{.md-button .md-button--primary}}
-[:octicons-gear-24:](){{.md-button}}
+
+??? note "View Options"
+    | Time Format |  |
+    | ------- | - |
+    | Long | <input type="button" class="md-button md-button--primary" value="#m #s ###ms" onclick="LongTime()"/> |
+    | Short | <input type="button" class="md-button" value="#:##.##"/> |
 

--- a/leaderboards/templates/records.md
+++ b/leaderboards/templates/records.md
@@ -9,7 +9,7 @@ search:
 <script src="/javascripts/leaderboards.js"></script>
 
 ??? note "View Options"
-    | Time Format |  |
-    | -------     | - |
-    | Long | <input type="button" id="long-time-format" class="md-button md-button--primary" value="#m #s ###ms" onclick="LongTime()"/> |
-    | WCA  | <input type="button" id="wca-time-format" class="md-button" value="#:##.##" onclick="ShortTime()"/> |
+    | Time Format |
+    | -------     |
+    | <input type="button" id="long-time-format" class="md-button md-button--primary" value="Long (1m 00s 000ms)" onclick="LongTime()"/> |
+    | <input type="button" id="wca-time-format" class="md-button" value="WCA (1:00.00)" onclick="ShortTime()"/> |

--- a/leaderboards/templates/records.md
+++ b/leaderboards/templates/records.md
@@ -5,3 +5,11 @@ search:
 ---
 
 # Current World Records :trophy-gold-hypercube:
+
+<script src="/javascripts/leaderboards.js"></script>
+
+??? note "View Options"
+    | Time Format |  |
+    | -------     | - |
+    | Long | <input type="button" id="long-time-format" class="md-button md-button--primary" value="#m #s ###ms" onclick="LongTime()"/> |
+    | WCA  | <input type="button" id="wca-time-format" class="md-button" value="#:##.##" onclick="ShortTime()"/> |

--- a/leaderboards/templates/solver.md
+++ b/leaderboards/templates/solver.md
@@ -7,7 +7,7 @@ search:
 <script src="/javascripts/leaderboards.js"></script>
 
 ??? note "View Options"
-    | Time Format |  |
-    | -------     | - |
-    | Long | <input type="button" id="long-time-format" class="md-button md-button--primary" value="#m #s ###ms" onclick="LongTime()"/> |
-    | WCA  | <input type="button" id="wca-time-format" class="md-button" value="#:##.##" onclick="ShortTime()"/> |
+    | Time Format |
+    | -------     |
+    | <input type="button" id="long-time-format" class="md-button md-button--primary" value="Long (1m 00s 000ms)" onclick="LongTime()"/> |
+    | <input type="button" id="wca-time-format" class="md-button" value="WCA (1:00.00)" onclick="ShortTime()"/> |

--- a/leaderboards/templates/solver.md
+++ b/leaderboards/templates/solver.md
@@ -3,3 +3,11 @@ title: {name}
 search:
   boost: 1
 ---
+
+<script src="/javascripts/leaderboards.js"></script>
+
+??? note "View Options"
+    | Time Format |  |
+    | -------     | - |
+    | Long | <input type="button" id="long-time-format" class="md-button md-button--primary" value="#m #s ###ms" onclick="LongTime()"/> |
+    | WCA  | <input type="button" id="wca-time-format" class="md-button" value="#:##.##" onclick="ShortTime()"/> |

--- a/leaderboards/test.csv
+++ b/leaderboards/test.csv
@@ -1,5 +1,5 @@
 date,       link,                  time, program,   solver,             puzzle, format
-2048-01-01, 2xx_2XNxxfA,    12:08:16.71, HSC,       rowan,            600-cell, single
-2048-01-02, 2xx_2XNxxfA,     3:21:22.23, M120C,     rowan,            120-cell, single
-2048-01-03, 2xx_2XNxxfA,        8:16.71, HSC,       rowan,              8-cell, single
-2048-01-04, 2xx_2XNxxfA,           1.01, HSC,       rowan,              1-cell, single
+2048-01-01, 2xx_2XNxxfA,    12:08:16.71, HSC,       rowan,            hemimegaminx, single
+2048-01-02, 2xx_2XNxxfA,     3:21:22.23, M120C,     vin,            hemimegaminx, single
+2048-01-03, 2xx_2XNxxfA,        8:16.71, HSC,       hactar,              hemimegaminx, single
+2048-01-04, 2xx_2XNxxfA,           1.01, HSC,       grant,              hemimegaminx, single

--- a/leaderboards/test.csv
+++ b/leaderboards/test.csv
@@ -1,0 +1,5 @@
+date,       link,                  time, program,   solver,             puzzle, format
+2048-01-01, 2xx_2XNxxfA,    12:08:16.71, HSC,       rowan,            600-cell, single
+2048-01-02, 2xx_2XNxxfA,     3:21:22.23, M120C,     rowan,            120-cell, single
+2048-01-03, 2xx_2XNxxfA,        8:16.71, HSC,       rowan,              8-cell, single
+2048-01-04, 2xx_2XNxxfA,           1.01, HSC,       rowan,              1-cell, single


### PR DESCRIPTION
# Description

This branch adds a section to _all leaderboard pages_ called **View Options** that lets you change how the speedsolving time is formatted. This setting stays even if you refresh the page, or visit other pages on the wiki (although it will be forgotten if the tab is closed). The motivation behind this change came about when we previously discovered a time rounding error, and then began discussing the different formats to represent the time. On the Discord server, members overwhelmingly voted to have the time format be changed to the WCA time format (ex: 1:00.00), however this branch adds a feature that allows switching between either of the formats.

In addition, I moved the content of the "other places where various records are kept" section to it's own page, called `other-leaderboards.md`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Refreshed pages, clicked between pages
- [x] Looked at several leaderboard tabs and verified visually that it works

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any UI changes have been checked to work on desktop, tablet, and mobile