### PR TITLE
Rephrase click here links

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -13,7 +13,9 @@ Shortly after the Rubik's Cube was invented in 1974, people began thinking about
 
 ## 2002-Present: Mailing List Years
 
-In August 2003, the Hypercubing Yahoo Groups mailing list was created. Anyone could subscribe to the list and join the discussion via email. This greatly improved the speed of sharing knowledge. Many new people joined and discussed methods, puzzles, and even had some speedsolving competitions! It was moderately active, up until Yahoo groups began removing past content in 2019. Click [here](https://hypercubing-archive.gitlab.io/) to view an archive of all the past messages. After that, the Hypercubing Google Groups mailing list was created, with pretty much the same members and type of discussions as before. It wasn't until 2021 that a Discord server was created to speed up communication even more.
+In August 2003, the Hypercubing Yahoo Groups mailing list was created. Anyone could subscribe to the list and join the discussion via email. This greatly improved the speed of sharing knowledge. Many new people joined and discussed methods and puzzles, and even had some speedsolving competitions! It was moderately active until Yahoo groups began removing content in 2019. Nowadays, there is an [archive](https://hypercubing-archive.gitlab.io/) of the messages from the Yahoo Groups mailing list.
+
+After the end of the Hypercubing Yahoo Groups mailing list, the Hypercubing Google Groups mailing list was created, with pretty much the same members and type of discussions as before. It wasn't until 2021 that a Discord server was created to speed up communication even more.
 
 ## 2010-2017: Andrey's Influence
 
@@ -57,4 +59,4 @@ In early 2024, the first speedsolves of the 3^5^ were done. A lot of hypercubers
 - **2022 Dec 22:** First 3^4^ sub-3:00 by Hactar
 - **2023 May 13:** First 3^4^ sub-2:00 by Hactar
 
-[^1]: Read Andrey's biography [here](https://superliminal.com/andrey/biography.html)
+[^1]: Read [Andrey's biography](https://superliminal.com/andrey/biography.html)

--- a/docs/methods/2x2x2x2-physical/p4l.md
+++ b/docs/methods/2x2x2x2-physical/p4l.md
@@ -4,7 +4,7 @@
 
 PBLBC/P4L/PAL is an advanced algorithm set for speedsolving Melinda’s Physical 2×2×2×2. It is used after orientation and separation of 2 opposite cells, followed by (or simultaneously) orienting both layers on both of those cells. This leaves you with two 2×2×2 PBL cases, one on each cell. The original idea for this came from Connor Lindsay, who created most of the algorithms in his [algorithm sheet](https://12070019537911455222.googlegroups.com/attach/161f36cf43a69/2x2x2x2%20Algortithm%20Sheet.pdf?part=0.1&view=1&vt=ANaJVrGw6i3FB09hTT_j1I-MrwlEO06HD4aNgAMeVX9dhKhuSAwlgi86dUTi35_aIYhKNcy2kDcCHsOiajFmrosVdlso2N6w7DZeADzufEf001q0wFc9hnw).
 
-2 years later, Rowan tried optimizing the algorithms, and compiling them in a new document, which can be found [here](https://docs.google.com/document/d/12CriaqJ1dYtAMpeY3c0dyLSCG9j37DEPKRWr4cl5i9U/edit?usp=sharing).
+Two years later, Rowan tried optimizing the algorithms, and compiled them in a [new algorithm sheet](https://docs.google.com/document/d/12CriaqJ1dYtAMpeY3c0dyLSCG9j37DEPKRWr4cl5i9U/edit?usp=sharing).
 
 ## Algorithms
 Each layer can be in 3 different permutations: solved, adjacent swap, and opposite swap. This gives us 81 cases, but some of these are impossible. Cases can also be rearranged via Case Manipulation, further reducing the number of cases to 29. Practically however, only a few algorithms are used because all the bad cases are really slow to execute.

--- a/docs/methods/2x2x2x2/4tega.md
+++ b/docs/methods/2x2x2x2/4tega.md
@@ -25,4 +25,4 @@ Same as in Variant 1.
 Use RKT to orient both layers of both cells, just like OBL in 3D Ortega. This can be done using the OCLL algorithms.
 
 ### P4L/PBLBC
-Permtue all 4 layers of both cells at once using algorithms. Some algorithms can be found [here](https://docs.google.com/document/d/12CriaqJ1dYtAMpeY3c0dyLSCG9j37DEPKRWr4cl5i9U/edit?usp=sharing).
+Permute all 4 layers of both cells at once using algorithms. Some algorithms can be found on Rowan's [PBLBC algorithms sheet](https://docs.google.com/document/d/12CriaqJ1dYtAMpeY3c0dyLSCG9j37DEPKRWr4cl5i9U/edit?usp=sharing).

--- a/docs/software/magiccube4d.md
+++ b/docs/software/magiccube4d.md
@@ -13,13 +13,9 @@ Magic Cube 4D requires [Java](https://www.java.com/en/) to be installed. Once yo
 
 ## Alternative versions
 
-### Raynefork
-
-Raynefork is Raymond Zhao's version of MC4D, which has the updated default colour scheme (standard 3^3^ colours plus pink/purple), and some more options in the settings menu. It can be found from its GitHub [here](https://github.com/rzhao271/magiccube4d/releases/tag/v4.3.343-raynefork.2.1).
-
 ### Don's version
 
-Don's version contains some 2D puzzles, many 3D puzzles, and some interesting 4D puzzles. It also has a menu for 5D and 6D puzzles, however they don't work when you select them. Don's version can be downloaded from its GitHub [here](https://github.com/donhatch/donhatchsw.jar/blob/master/java1.8/donhatchsw.jar).
+Don's version contains some 2D puzzles, many 3D puzzles, and some interesting 4D puzzles. It also has a menu for 5D and 6D puzzles, however they don't work when you select them. Don's version can be downloaded directly from his [GitHub release](https://github.com/donhatch/donhatchsw.jar/blob/master/java1.8/donhatchsw.jar).
 
 
 ## Troubleshooting

--- a/docs/techniques/rkt.md
+++ b/docs/techniques/rkt.md
@@ -4,7 +4,7 @@
 
 RKT is a technique that lets you treat a single cell of a (cell-turning) higher dimensional puzzle as if it were a lower dimensional puzzle. This is very useful to do moves that damage fewer pieces. For example: RKT lets you treat a side of a 3^4^ just like a 3^3^ cube, meaning that you can use all the 3D algorithms you already know to solve the full 4D puzzle.
 
-It has been invented independently several times, but was mainly popularized by Raymond Zhao in his article [here](https://rayzz.me/articles/hypercubing/rkt.html).
+The technique has been independently discovered several times, but the term was mainly popularized by Raymond Zhao, such as in his [article on RKT](https://rayzz.me/articles/hypercubing/rkt.html).
 
 ## Naming
 


### PR DESCRIPTION
This PR
- Avoids references to "click here" links, which are not friendly for screenreader users and not very descriptive in general.
- Removes the reference to MC4D Raynefork, considering that it isn't currently in development _and_ contains bugs that render it unusable.