### PR TITLE
Add new option to view date as relative (x months ago) instead of ISO (yyyy-mm-dd)

### DIFF
--- a/docs/javascripts/leaderboards.js
+++ b/docs/javascripts/leaderboards.js
@@ -35,7 +35,7 @@ function RelativeDate() {
     } 
     document.getElementById("relative-date-format").classList.add("md-button--primary"); 
     document.getElementById("iso-date-format").classList.remove("md-button--primary"); 
-    // sessionStorage.setItem("timeFormat", "long");
+    sessionStorage.setItem("dateFormat", "relative");
 }
 
 function ISODate() {
@@ -46,7 +46,7 @@ function ISODate() {
     } 
     document.getElementById("iso-date-format").classList.add("md-button--primary"); 
     document.getElementById("relative-date-format").classList.remove("md-button--primary"); 
-    // sessionStorage.setItem("timeFormat", "long");
+    sessionStorage.setItem("dateFormat", "iso");
 }
 
 
@@ -54,12 +54,18 @@ document.addEventListener("DOMContentLoaded", load);
 document.addEventListener("hashchange", load);
 
 function load() {
-    console.log("loaded thing");
-    var format = sessionStorage.getItem("timeFormat");
-    if (format == "short") {
+    // load cookies for view options
+    var timeFormat = sessionStorage.getItem("timeFormat");
+    if (timeFormat == "short") {
         ShortTime();
     } else {
         LongTime();
+    }
+    var dateFormat = sessionStorage.getItem("dateFormat");
+    if (dateFormat == "relative") {
+        RelativeDate();
+    } else {
+        ISODate();
     }
 }
 

--- a/docs/javascripts/leaderboards.js
+++ b/docs/javascripts/leaderboards.js
@@ -2,6 +2,9 @@
 var shortList = document.getElementsByClassName("shorttime");
 var longList = document.getElementsByClassName("longtime");
 
+var isoList = document.getElementsByClassName("isodate");
+var relativeList = document.getElementsByClassName("relativedate");
+
 function LongTime() {
     // switches to the long time format
     for (var i = 0; i < shortList.length; i++) {
@@ -22,9 +25,29 @@ function ShortTime() {
     document.getElementById("long-time-format").classList.remove("md-button--primary"); 
     document.getElementById("wca-time-format").classList.add("md-button--primary"); 
     sessionStorage.setItem("timeFormat", "short");
-    
 }
 
+function RelativeDate() {
+    // switches to the relative date format
+    for (var i = 0; i < isoList.length; i++) {
+        isoList[i].style.display = "none";
+        relativeList[i].style.display = "block";
+    } 
+    document.getElementById("relative-date-format").classList.add("md-button--primary"); 
+    document.getElementById("iso-date-format").classList.remove("md-button--primary"); 
+    // sessionStorage.setItem("timeFormat", "long");
+}
+
+function ISODate() {
+    // switches to the iso date format
+    for (var i = 0; i < relativeList.length; i++) {
+        relativeList[i].style.display = "none";
+        isoList[i].style.display = "block";
+    } 
+    document.getElementById("iso-date-format").classList.add("md-button--primary"); 
+    document.getElementById("relative-date-format").classList.remove("md-button--primary"); 
+    // sessionStorage.setItem("timeFormat", "long");
+}
 
 
 document.addEventListener("DOMContentLoaded", load);

--- a/leaderboards/generate_leaderboards.py
+++ b/leaderboards/generate_leaderboards.py
@@ -142,7 +142,7 @@ class Solve:
 
         self._cell_contents = {
             # 'date': self.date,
-            'date': f'<p class=\'isodate\'>{formatted_date[0]}</p><p style=\'display: none\' class=\'relativedate\'>{formatted_date[1]}</p>',
+            'date': f'<span class=\'isodate\'>{formatted_date[0]}</span><span style=\'display: none\' class=\'relativedate\'>{formatted_date[1]}</span>',
             'time': f'<a class=\'longtime\' href={self.link}>{formatted_time[0]}</a><a style=\'display: none\' class=\'shorttime\' href={self.link}>{formatted_time[1]}</a>' if link else formatted_time,
             'event': self.event.name,
             'program': self.program,

--- a/leaderboards/generate_leaderboards.py
+++ b/leaderboards/generate_leaderboards.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import timedelta
+from datetime import date
 from typing import List, Optional, Tuple
 import csv
 import math
@@ -91,6 +92,24 @@ def format_time(duration) -> str:  # duration: timedelta | int
     # return returnString + longTime + "</a>"
     return [longTime, shortTime]
 
+def format_date(isodate) -> str:
+    diff =  date.today() - date.fromisoformat(isodate)
+    relative = ""
+    if diff.days < 0:
+        relative == "Tomorrow"
+    elif diff.days == 0:
+        relative = "Today"
+    elif diff.days == 1:
+        relative = "Yesterday"
+    elif diff.days >= 7 and diff.days < 365:
+        a = "" if int(diff.days)/7 == 1 else "s"
+        relative = f"{int(diff.days/7)} week{a} ago"
+    elif diff.days >= 365:
+        a = "" if int(diff.days)/365 == 1 else "s"
+        relative = f"{int(diff.days/365)} year{a} ago"
+    else: 
+        relative = f"{diff.days} days ago"
+    return [isodate, relative]
 
 
 class Solve:
@@ -116,8 +135,11 @@ class Solve:
         self.solver.solves_by_event[self.event.id].append(self)
         self.rank = None
         formatted_time = format_time(self.time)
+        formatted_date = format_date(self.date)
+
         self._cell_contents = {
-            'date': self.date,
+            # 'date': self.date,
+            'date': f'<p class=\'isodate\'>{formatted_date[0]}</p><p style=\'display: none\' class=\'relativedate\'>{formatted_date[1]}</p>',
             'time': f'<a class=\'longtime\' href={self.link}>{formatted_time[0]}</a><a style=\'display: none\' class=\'shorttime\' href={self.link}>{formatted_time[1]}</a>' if link else formatted_time,
             'event': self.event.name,
             'program': self.program,

--- a/leaderboards/generate_leaderboards.py
+++ b/leaderboards/generate_leaderboards.py
@@ -96,19 +96,19 @@ def format_date(isodate) -> str:
     diff =  date.today() - date.fromisoformat(isodate)
     relative = ""
     if diff.days < 0:
-        relative == "Tomorrow"
+        relative = "Tomorrow"
     elif diff.days == 0:
         relative = "Today"
     elif diff.days == 1:
         relative = "Yesterday"
     elif diff.days >= 7 and diff.days < 30:
-        a = "s" if abs(int(diff.days)/7) != 1 else ""
+        a = "s" if diff.days >= 7*2 else ""
         relative = f"{int(diff.days/7)} week{a} ago"
-    elif diff.days >= 30 and diff.days < 365:
-        a = "s" if abs(int(diff.days)/30.4) != 1 else ""
+    elif diff.days >= 30.4 and diff.days < 365:
+        a = "s" if diff.days >= 30.4*2 else ""
         relative = f"{int(diff.days/30.4)} month{a} ago"
     elif diff.days >= 365:
-        a = "s" if abs(int(diff.days)/365) != 1 else ""
+        a = "s" if diff.days >= 365*2 else ""
         relative = f"{int(diff.days/365)} year{a} ago"
     else: 
         relative = f"{diff.days} days ago"

--- a/leaderboards/generate_leaderboards.py
+++ b/leaderboards/generate_leaderboards.py
@@ -101,11 +101,14 @@ def format_date(isodate) -> str:
         relative = "Today"
     elif diff.days == 1:
         relative = "Yesterday"
-    elif diff.days >= 7 and diff.days < 365:
-        a = "" if int(diff.days)/7 == 1 else "s"
+    elif diff.days >= 7 and diff.days < 30:
+        a = "s" if abs(int(diff.days)/7) != 1 else ""
         relative = f"{int(diff.days/7)} week{a} ago"
+    elif diff.days >= 30 and diff.days < 365:
+        a = "s" if abs(int(diff.days)/30.4) != 1 else ""
+        relative = f"{int(diff.days/30.4)} month{a} ago"
     elif diff.days >= 365:
-        a = "" if int(diff.days)/365 == 1 else "s"
+        a = "s" if abs(int(diff.days)/365) != 1 else ""
         relative = f"{int(diff.days/365)} year{a} ago"
     else: 
         relative = f"{diff.days} days ago"

--- a/leaderboards/templates/history.md
+++ b/leaderboards/templates/history.md
@@ -9,7 +9,7 @@ search:
 <script src="/javascripts/leaderboards.js"></script>
 
 ??? note "View Options"
-    | Time Format |
-    | -------     |
-    | <input type="button" id="long-time-format" class="md-button md-button--primary" value="Long (1m 00s 000ms)" onclick="LongTime()"/> |
-    | <input type="button" id="wca-time-format" class="md-button" value="WCA (1:00.00)" onclick="ShortTime()"/> |
+    | Time Format | Date Format |
+    | -------     | -- |
+    | <input type="button" id="long-time-format" class="md-button md-button--primary" value="Long (1m 00s 000ms)" onclick="LongTime()"/> | <input type="button" id="iso-date-format" class="md-button md-button--primary" value="ISO 8601 (YYYY-MM-DD)" onclick="ISODate()"/>
+    | <input type="button" id="wca-time-format" class="md-button" value="WCA (1:00.00)" onclick="ShortTime()"/> | <input type="button" id="relative-date-format" class="md-button" value="Relative (__ days ago)" onclick="RelativeDate()"/> |

--- a/leaderboards/templates/leaderboards.md
+++ b/leaderboards/templates/leaderboards.md
@@ -24,8 +24,8 @@ World record database for higher dimensional twisty puzzle speedsolving!
 [:material-plus-circle: Submit](https://forms.gle/Y7Vpi3pb8989Ay8W8){{.md-button .md-button--primary}}
 
 ??? note "View Options"
-    | Time Format |
-    | -------     |
-    | <input type="button" id="long-time-format" class="md-button md-button--primary" value="Long (1m 00s 000ms)" onclick="LongTime()"/> |
-    | <input type="button" id="wca-time-format" class="md-button" value="WCA (1:00.00)" onclick="ShortTime()"/> |
+    | Time Format | Date Format |
+    | -------     | -- |
+    | <input type="button" id="long-time-format" class="md-button md-button--primary" value="Long (1m 00s 000ms)" onclick="LongTime()"/> | <input type="button" id="iso-date-format" class="md-button md-button--primary" value="ISO 8601 (YYYY-MM-DD)" onclick="ISODate()"/>
+    | <input type="button" id="wca-time-format" class="md-button" value="WCA (1:00.00)" onclick="ShortTime()"/> | <input type="button" id="relative-date-format" class="md-button" value="Relative (__ days ago)" onclick="RelativeDate()"/> |
 

--- a/leaderboards/templates/records.md
+++ b/leaderboards/templates/records.md
@@ -9,7 +9,7 @@ search:
 <script src="/javascripts/leaderboards.js"></script>
 
 ??? note "View Options"
-    | Time Format |
-    | -------     |
-    | <input type="button" id="long-time-format" class="md-button md-button--primary" value="Long (1m 00s 000ms)" onclick="LongTime()"/> |
-    | <input type="button" id="wca-time-format" class="md-button" value="WCA (1:00.00)" onclick="ShortTime()"/> |
+    | Time Format | Date Format |
+    | -------     | -- |
+    | <input type="button" id="long-time-format" class="md-button md-button--primary" value="Long (1m 00s 000ms)" onclick="LongTime()"/> | <input type="button" id="iso-date-format" class="md-button md-button--primary" value="ISO 8601 (YYYY-MM-DD)" onclick="ISODate()"/>
+    | <input type="button" id="wca-time-format" class="md-button" value="WCA (1:00.00)" onclick="ShortTime()"/> | <input type="button" id="relative-date-format" class="md-button" value="Relative (__ days ago)" onclick="RelativeDate()"/> |

--- a/leaderboards/templates/solver.md
+++ b/leaderboards/templates/solver.md
@@ -7,7 +7,7 @@ search:
 <script src="/javascripts/leaderboards.js"></script>
 
 ??? note "View Options"
-    | Time Format |
-    | -------     |
-    | <input type="button" id="long-time-format" class="md-button md-button--primary" value="Long (1m 00s 000ms)" onclick="LongTime()"/> |
-    | <input type="button" id="wca-time-format" class="md-button" value="WCA (1:00.00)" onclick="ShortTime()"/> |
+    | Time Format | Date Format |
+    | -------     | -- |
+    | <input type="button" id="long-time-format" class="md-button md-button--primary" value="Long (1m 00s 000ms)" onclick="LongTime()"/> | <input type="button" id="iso-date-format" class="md-button md-button--primary" value="ISO 8601 (YYYY-MM-DD)" onclick="ISODate()"/>
+    | <input type="button" id="wca-time-format" class="md-button" value="WCA (1:00.00)" onclick="ShortTime()"/> | <input type="button" id="relative-date-format" class="md-button" value="Relative (__ days ago)" onclick="RelativeDate()"/> |


### PR DESCRIPTION
It will default to the old option. It also stores this setting as a cookie, so if you close the tab or refresh the page it stays on whichever view option you want :)